### PR TITLE
fix: :bug: 修复在promise.then()里的内容需要return 一个promise才能正常按顺序执行

### DIFF
--- a/node/async/serial/index.js
+++ b/node/async/serial/index.js
@@ -19,11 +19,19 @@ const promise = (name, delay = 100) => new Promise(resolve => {
 })
 
 exports.promise = () => {
-
-    promise('Promise1')
-        .then(promise('Promise2'))
-        .then(promise('Promise3'))
-        .then(promise('Promise4'))
+    
+    promise('Promise1',600)
+        .then((res) => {
+            return promise('Promise2',500)
+        })
+        .then(
+            (res) => {
+                return promise('Promise3',100)
+            })
+        .then(
+            (res) => {
+                return promise('Promise4',200)
+            })
 }
 
 exports.generator = () => {


### PR DESCRIPTION
原例子如果修改不同时间间隔，执行顺便并不能按顺序执行，在then()里面return 新的Promise对象可以按顺序执行